### PR TITLE
Pin the version of the Dart API package.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ dependencies:
   destiny2_api:
     git:
       url: https://github.com/pylaligand/destiny2-dart-api-client.git
-      ref: master
+      ref: effaa03479799638f4332f09385e218a8e929b0f
   heroku_slack_bot:
     git:
       url: https://github.com/pylaligand/heroku-slack-bot.git


### PR DESCRIPTION
This makes it easier to force a rebuild of the app when the bindings are updated.